### PR TITLE
替换掉html实体内容，如&nbsp; &lt等;匹配掉laravel-admin 列展开中相关内容

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -45,7 +45,7 @@ class Exporter extends AbstractExporter implements FromCollection, WithHeadings,
     private $registerEvents = [];
 
     protected $htmlEntities = [
-        '&nbsp;', '&lt;', '&gt;', '&amp;', '&quot;', '&cent;', '&pound;', '&yen;', '&euro;', '&sect;', '&copy;', '&reg;', '&trade;', '&times;', '&divide;'
+        '&nbsp;', '&lt;', '&gt;', '&amp;', '&quot;', '&cent;', '&pound;', '&yen;', '&euro;', '&sect;', '&copy;', '&reg;', '&trade;', '&times;', '&divide;','\\n'
     ];
 
     /**
@@ -81,7 +81,7 @@ class Exporter extends AbstractExporter implements FromCollection, WithHeadings,
         foreach ($this->grid->rows() as $row) {
             $data = [];
             foreach ($this->columns as $key => $column) {
-                $data[$column] = trim(str_replace($this->htmlEntities, '', strip_tags(preg_replace(/** @lang text */ '/<script(.*)>(.*)<\/script>/iUs', '', $row->column($key)))));
+                $data[$column] = trim(str_replace($this->htmlEntities, '', strip_tags(preg_replace(/** @lang text */ '/<script(.*)>(.*)<\/script>|<template(.*)>(.*)<\/template>/iUs', '', $row->column($key)))));
             }
             $lists[] = $data;
         }

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -25,165 +25,163 @@ use Maatwebsite\Excel\Concerns\WithCustomValueBinder;
 
 class Exporter extends AbstractExporter implements FromCollection, WithHeadings, ShouldAutoSize, WithCustomValueBinder, WithEvents
 {
-	use Exportable;
-	/**
-	 * @var array $columns
-	 */
-	private $columns = [];
-	/**
-	 * @var string $fileName 文件名
-	 */
-	private $fileName = 'Exporter.xlsx';
-	/**
-	 * @var array $exclusions 排除项
-	 */
-	private $exclusions = [];
-	/**
-	 * @var array $registerEvents
-	 */
-	private $registerEvents = [];
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function headings() : array
-	{
-		if(!empty($this->columns))
-		{
-			return $this->columns;
-		}
-		
-		$this->exclusions = collect($this->exclusions)->map(static function($exclusion)
-		{
-			return Str::snake($exclusion);
-		});
-		
-		$this->columns = $this->grid->visibleColumns()->mapWithKeys(static function(Column $column)
-		{
-			return [$column->getName() => $column->getLabel()];
-		})->except($this->exclusions);
-		
-		return $this->columns->toArray();
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function collection()
-	{
-		$lists = [];
-		$this->grid->build();
-		/**
-		 * @var Row $row
-		 */
-		foreach($this->grid->rows() as $row)
-		{
-			$data = [];
-			foreach($this->columns as $key => $column)
-			{
-				$data[$column] = trim(strip_tags(preg_replace(/** @lang text */ '/<script(.*)>(.*)<\/script>/iUs', '', $row->column($key))));
-			}
-			$lists[] = $data;
-		}
-		
-		return new Collection($lists);
-	}
-	
-	/**
-	 * {@inheritdoc}
-	 */
-	public function export()
-	{
-		$this->download($this->fileName)->prepare(request())->send();
-		
-		exit;
-	}
-	
-	/**
-	 * @inheritDoc
-	 * @throws Exception
-	 */
-	public function bindValue(Cell $cell, $value)
-	{
-		$cell->setValueExplicit($value, DataType::TYPE_STRING);
-		
-		return true;
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function registerEvents() : array
-	{
-		return $this->registerEvents;
-	}
-	
-	/**
-	 * 设置文件名
-	 *
-	 * @param string $fileName
-	 *
-	 * @return Exporter
-	 */
-	public function setFileName(string $fileName) : Exporter
-	{
-		if(empty(pathinfo($fileName, PATHINFO_EXTENSION)))
-		{
-			$fileName .= '.xlsx';
-		}
-		$this->fileName = $fileName;
-		
-		return $this;
-	}
-	
-	/**
-	 * 排除项
-	 *
-	 * @param array $exclusions
-	 *
-	 * @return Exporter
-	 */
-	public function setExclusions(array $exclusions) : Exporter
-	{
-		$this->exclusions = array_merge_recursive($this->exclusions, $exclusions);
-		
-		return $this;
-	}
-	
-	/**
-	 * 排除项
-	 *
-	 * @param string $exclusion
-	 *
-	 * @return Exporter
-	 */
-	public function setExclusion(string $exclusion) : Exporter
-	{
-		$this->exclusions[] = $exclusion;
-		
-		return $this;
-	}
-	
-	/**
-	 * @param array $registerEvents
-	 */
-	public function setRegisterEvents(array $registerEvents) : void
-	{
-		$this->registerEvents = $registerEvents;
-	}
-	
-	/**
-	 * 获取 Grid exporter
-	 *
-	 * @param Grid $grid
-	 *
-	 * @return NULL|Exporter
-	 */
-	public static function get(Grid $grid) : ?Exporter
-	{
-		return (function()
-		{
-			return $this->exporter instanceof Exporter ? $this->exporter : null;
-		})->call($grid);
-	}
+    use Exportable;
+
+    /**
+     * @var array $columns
+     */
+    private $columns = [];
+    /**
+     * @var string $fileName 文件名
+     */
+    private $fileName = 'Exporter.xlsx';
+    /**
+     * @var array $exclusions 排除项
+     */
+    private $exclusions = [];
+    /**
+     * @var array $registerEvents
+     */
+    private $registerEvents = [];
+
+    protected $htmlEntities = [
+        '&nbsp;', '&lt;', '&gt;', '&amp;', '&quot;', '&cent;', '&pound;', '&yen;', '&euro;', '&sect;', '&copy;', '&reg;', '&trade;', '&times;', '&divide;'
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function headings(): array
+    {
+        if (!empty($this->columns)) {
+            return $this->columns;
+        }
+
+        $this->exclusions = collect($this->exclusions)->map(static function ($exclusion) {
+            return Str::snake($exclusion);
+        });
+
+        $this->columns = $this->grid->visibleColumns()->mapWithKeys(static function (Column $column) {
+            return [$column->getName() => $column->getLabel()];
+        })->except($this->exclusions);
+
+        return $this->columns->toArray();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function collection()
+    {
+        $lists = [];
+        $this->grid->build();
+        /**
+         * @var Row $row
+         */
+        foreach ($this->grid->rows() as $row) {
+            $data = [];
+            foreach ($this->columns as $key => $column) {
+                $data[$column] = trim(str_replace($this->htmlEntities, '', strip_tags(preg_replace(/** @lang text */ '/<script(.*)>(.*)<\/script>/iUs', '', $row->column($key)))));
+            }
+            $lists[] = $data;
+        }
+
+        return new Collection($lists);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function export()
+    {
+        $this->download($this->fileName)->prepare(request())->send();
+
+        exit;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception
+     */
+    public function bindValue(Cell $cell, $value)
+    {
+        $cell->setValueExplicit($value, DataType::TYPE_STRING);
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function registerEvents(): array
+    {
+        return $this->registerEvents;
+    }
+
+    /**
+     * 设置文件名
+     *
+     * @param string $fileName
+     *
+     * @return Exporter
+     */
+    public function setFileName(string $fileName): Exporter
+    {
+        if (empty(pathinfo($fileName, PATHINFO_EXTENSION))) {
+            $fileName .= '.xlsx';
+        }
+        $this->fileName = $fileName;
+
+        return $this;
+    }
+
+    /**
+     * 排除项
+     *
+     * @param array $exclusions
+     *
+     * @return Exporter
+     */
+    public function setExclusions(array $exclusions): Exporter
+    {
+        $this->exclusions = array_merge_recursive($this->exclusions, $exclusions);
+
+        return $this;
+    }
+
+    /**
+     * 排除项
+     *
+     * @param string $exclusion
+     *
+     * @return Exporter
+     */
+    public function setExclusion(string $exclusion): Exporter
+    {
+        $this->exclusions[] = $exclusion;
+
+        return $this;
+    }
+
+    /**
+     * @param array $registerEvents
+     */
+    public function setRegisterEvents(array $registerEvents): void
+    {
+        $this->registerEvents = $registerEvents;
+    }
+
+    /**
+     * 获取 Grid exporter
+     *
+     * @param Grid $grid
+     *
+     * @return NULL|Exporter
+     */
+    public static function get(Grid $grid): ?Exporter
+    {
+        return (function () {
+            return $this->exporter instanceof Exporter ? $this->exporter : null;
+        })->call($grid);
+    }
 }


### PR DESCRIPTION
替换掉html实体内容，如&nbsp; &lt等;

匹配掉laravel-admin 列展开中相关内容;
![image](https://user-images.githubusercontent.com/40051171/131432544-5a38b09a-0fbc-4165-bc6e-de3ce503da0e.png)
